### PR TITLE
Fix photo loading and upload on Android

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-disabled: false
 
       - name: Setup Expo
         uses: expo/expo-github-action@v8

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -20,6 +20,7 @@ import { AuthRepository } from './src/infra/auth.repository';
 import { AuthUseCase } from './src/usecase/auth.usecase';
 import { BACKGROUND_SYNC_TASK } from './src/domain/constants';
 import { S3Repository } from './src/infra/s3.repository';
+import DebugLogger from './src/infra/debug-logger';
 
 const AppContext = createContext<any>(null);
 const Stack = createNativeStackNavigator();
@@ -162,6 +163,10 @@ const MainDrawerNavigator = () => {
 
 export default function App() {
   const { session, loading, login, logout } = useAuth();
+
+  useEffect(() => {
+    DebugLogger.log('App Started', `Env: ${Platform.OS}, Staging: ${isStaging}`);
+  }, []);
   const [backendVersion, setBackendVersion] = React.useState('...');
   const authUseCase = useMemo(() => new AuthUseCase(authRepo), []);
 

--- a/frontend/e2e/app.spec.ts
+++ b/frontend/e2e/app.spec.ts
@@ -23,7 +23,8 @@ test.describe('Photo Cloud App', () => {
     const emptyMessage = page.getByText('No photos found.');
 
     // Wait for the gallery to at least start showing something
-    await expect(galleryItems.first().or(errorItems.first()).or(emptyMessage)).toBeVisible({ timeout: 60000 });
+    // We only check for gallery items or empty message. Error items (⚠️) are inside photo items now.
+    await expect(galleryItems.first().or(emptyMessage)).toBeVisible({ timeout: 60000 });
 
     // Wait for synchronization to complete
     await expect(page.getByText('Mise à jour...')).not.toBeVisible({ timeout: 60000 });

--- a/frontend/e2e/photos_albums.spec.ts
+++ b/frontend/e2e/photos_albums.spec.ts
@@ -50,8 +50,8 @@ test.describe('Photos and Albums Flow', () => {
     await page.getByTestId('new-album-title-input').fill(albumTitle);
     await page.getByTestId('confirm-create-album-button').click();
 
-    // Verify dialog closed
-    await expect(page.getByText('Ajouter aux albums')).not.toBeVisible({ timeout: 15000 });
+    // Verify dialog closed (we check the dialog title)
+    await expect(page.getByRole('heading', { name: 'Ajouter aux albums' })).not.toBeVisible({ timeout: 15000 });
 
     // 3. Go to Albums screen and verify
     await page.goto('/#');

--- a/frontend/eas.json
+++ b/frontend/eas.json
@@ -9,7 +9,9 @@
     },
     "preview": {
       "distribution": "internal",
-      "gradleCommand": ":app:assembleDebug",
+      "android": {
+        "gradleCommand": ":app:assembleDebug"
+      },
       "env": {
         "EXPO_PUBLIC_API_URL": "https://photocloud.alwaysdata.net"
       }

--- a/frontend/eas.json
+++ b/frontend/eas.json
@@ -10,8 +10,7 @@
     "preview": {
       "distribution": "internal",
       "android": {
-        "buildType": "apk",
-        "gradleCommand": ":app:assembleDebug"
+        "buildType": "apk"
       },
       "env": {
         "EXPO_PUBLIC_API_URL": "https://photocloud.alwaysdata.net"

--- a/frontend/eas.json
+++ b/frontend/eas.json
@@ -9,6 +9,7 @@
     },
     "preview": {
       "distribution": "internal",
+      "gradleCommand": ":app:assembleDebug",
       "env": {
         "EXPO_PUBLIC_API_URL": "https://photocloud.alwaysdata.net"
       }

--- a/frontend/eas.json
+++ b/frontend/eas.json
@@ -10,6 +10,7 @@
     "preview": {
       "distribution": "internal",
       "android": {
+        "buildType": "apk",
         "gradleCommand": ":app:assembleDebug"
       },
       "env": {

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -4,6 +4,8 @@ import { registerRootComponent } from 'expo';
 import 'react-native-get-random-values';
 import { Buffer } from 'buffer';
 global.Buffer = Buffer;
+import process from 'process';
+global.process = process;
 
 import * as TaskManager from 'expo-task-manager';
 import { SyncPhotosUseCase } from './src/usecase/sync-photos.usecase';

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -2,8 +2,8 @@ import 'react-native-gesture-handler';
 import 'react-native-reanimated'; 
 import { registerRootComponent } from 'expo';
 import 'react-native-get-random-values';
-//import { Buffer } from 'buffer';
-//global.Buffer = Buffer;
+import { Buffer } from 'buffer';
+global.Buffer = Buffer;
 
 import * as TaskManager from 'expo-task-manager';
 import { SyncPhotosUseCase } from './src/usecase/sync-photos.usecase';

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -2,4 +2,12 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/*.test.ts'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', {
+      tsconfig: 'tsconfig.json',
+    }],
+  },
+  transformIgnorePatterns: [
+    'node_modules/(?!(expo|@expo|expo-file-system|expo-asset|expo-constants|expo-modules-core|react-native|@react-native|@react-navigation|@react-native-community|lucide-react-native)/)',
+  ],
 };

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -3,11 +3,11 @@ module.exports = {
   testEnvironment: 'node',
   testMatch: ['**/*.test.ts'],
   transform: {
-    '^.+\\.tsx?$': ['ts-jest', {
+    '^.+\\.(ts|tsx|js|jsx)$': ['ts-jest', {
       tsconfig: 'tsconfig.json',
     }],
   },
   transformIgnorePatterns: [
-    'node_modules/(?!(expo|@expo|expo-file-system|expo-asset|expo-constants|expo-modules-core|react-native|@react-native|@react-navigation|@react-native-community|lucide-react-native)/)',
+    'node_modules/(?!(expo|@expo|expo-crypto|expo-file-system|expo-asset|expo-constants|expo-modules-core|react-native|@react-native|@react-navigation|@react-native-community|lucide-react-native)/)',
   ],
 };

--- a/frontend/metro.config.js
+++ b/frontend/metro.config.js
@@ -9,6 +9,7 @@ config.resolver.extraNodeModules = {
   stream: require.resolve('stream-browserify'),
   buffer: require.resolve('buffer'),
   process: require.resolve('process/browser'),
+  events: require.resolve('events'),
 };
 
 // FIX: Exclure le dossier android et les fichiers temporaires de build

--- a/frontend/metro.config.js
+++ b/frontend/metro.config.js
@@ -8,6 +8,7 @@ config.resolver.extraNodeModules = {
   crypto: require.resolve('crypto-browserify'),
   stream: require.resolve('stream-browserify'),
   buffer: require.resolve('buffer'),
+  process: require.resolve('process/browser'),
 };
 
 // FIX: Exclure le dossier android et les fichiers temporaires de build

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "expo-build-properties": "~55.0.10",
     "expo-crypto": "~55.0.10",
     "expo-document-picker": "~55.0.9",
+    "expo-file-system": "^55.0.11",
     "expo-image-manipulator": "~55.0.11",
     "expo-linking": "~55.0.8",
     "expo-media-library": "~55.0.10",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "@shopify/flash-list": "2.0.2",
     "buffer": "^6.0.3",
     "crypto-browserify": "^3.12.1",
+    "events": "^3.3.0",
     "exifr": "^7.1.3",
     "expo": "^55.0.0",
     "expo-auth-session": "~55.0.9",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,7 @@
     "lucide-react-native": "^0.378.0",
     "patch-package": "^8.0.1",
     "postinstall-postinstall": "^2.1.0",
+    "process": "^0.11.10",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-native": "0.83.2",

--- a/frontend/src/infra/album.repository.ts
+++ b/frontend/src/infra/album.repository.ts
@@ -145,7 +145,7 @@ export class AlbumRepository implements IAlbumRepository {
 
         try {
             // 3. Try to Load Index
-            console.log(`AlbumRepository: Fetching index ${indexKey}`);
+            DebugLogger.log('Album Fetch', `Fetching index ${indexKey} for ${email}`);
             const indexData = await this.s3Repo.getFile(bucket, indexKey);
             const decoded = decodeText(indexData);
             DebugLogger.log('Album Index Loaded', `${indexKey}: len=${decoded.length}, start=${decoded.substring(0, 50)}`);

--- a/frontend/src/infra/album.repository.ts
+++ b/frontend/src/infra/album.repository.ts
@@ -145,7 +145,9 @@ export class AlbumRepository implements IAlbumRepository {
             // 3. Try to Load Index
             console.log(`AlbumRepository: Fetching index ${indexKey}`);
             const indexData = await this.s3Repo.getFile(bucket, indexKey);
-            const albums = JSON.parse(decodeText(indexData)) as Album[];
+            const decoded = decodeText(indexData);
+            console.log(`AlbumRepository: Loaded index ${indexKey}, length: ${decoded.length}`);
+            const albums = JSON.parse(decoded) as Album[];
 
             localAlbums = albums.filter(a => {
                 if (!a.albumKey) {
@@ -168,7 +170,9 @@ export class AlbumRepository implements IAlbumRepository {
 
         } catch (e: any) {
             if (e.name !== 'NoSuchKey' && e.$metadata?.httpStatusCode !== 404) {
-                console.error(`Failed to load index ${indexKey}, falling back to full listing`, e);
+                console.error(`AlbumRepository: Failed to load index ${indexKey}, falling back to full listing`, e);
+            } else {
+                console.log(`AlbumRepository: Index ${indexKey} not found (404), falling back to full listing`);
             }
 
             // 4. Fallback: Full Listing
@@ -221,7 +225,9 @@ export class AlbumRepository implements IAlbumRepository {
         albumsCache.set(indexKey, { data: lightLocalAlbums, timestamp: Date.now() });
 
         // 7. Return combined list (with full photoKeys for shared if they were just discovered, or light if preferred)
-        return [...localAlbums, ...sharedAlbums];
+        const combined = [...localAlbums, ...sharedAlbums];
+        console.log(`AlbumRepository: Returning ${combined.length} combined albums (${localAlbums.length} local, ${sharedAlbums.length} shared) for ${email}`);
+        return combined;
     })();
 
     pendingRequests.set(indexKey, request);

--- a/frontend/src/infra/album.repository.ts
+++ b/frontend/src/infra/album.repository.ts
@@ -3,6 +3,7 @@ import { encodeText, decodeText, uint8ArrayToBase64, limitConcurrency } from './
 import { GlobalLock } from './locks';
 import * as Crypto from 'expo-crypto';
 import { Alert, Platform } from 'react-native';
+import DebugLogger from './debug-logger';
 
 // Simple memory cache for albums index to speed up navigation
 export const albumsCache = new Map<string, { data: Album[], timestamp: number }>();
@@ -147,34 +148,32 @@ export class AlbumRepository implements IAlbumRepository {
             console.log(`AlbumRepository: Fetching index ${indexKey}`);
             const indexData = await this.s3Repo.getFile(bucket, indexKey);
             const decoded = decodeText(indexData);
-            console.log(`AlbumRepository: Loaded index ${indexKey}, length: ${decoded.length}`);
+            DebugLogger.log('Album Index Loaded', `${indexKey}: len=${decoded.length}, start=${decoded.substring(0, 50)}`);
             let albums;
             try {
                 albums = JSON.parse(decoded) as Album[];
             } catch (err: any) {
-                console.error(`AlbumRepository: Failed to parse index JSON: ${decoded.substring(0, 100)}`, err);
-                if (Platform.OS === 'android') {
-                    Alert.alert('JSON Parse Error', `Failed to parse albums index: ${err.message}`);
-                }
+                DebugLogger.error('Album JSON Parse', `Failed for ${indexKey}`, err);
                 throw err;
             }
 
-            console.log(`AlbumRepository: Filtering ${albums.length} albums for email: ${email}`);
+            DebugLogger.log('Album Filtering', `Filtering ${albums.length} albums for ${email}`);
             localAlbums = albums.filter(a => {
                 if (!a.albumKey) {
-                    console.warn(`AlbumRepository: Hiding incompatible old album ${a.id} from index`);
+                    DebugLogger.log('Album Filter Skip', `Hiding incompatible old album ${a.id} (no albumKey)`);
                     needsIndexUpdate = true;
                     return false;
                 }
                 // Only keep local albums in the local index
-                if (a.ownerEmail && a.ownerEmail.toLowerCase() !== email.toLowerCase()) {
-                    console.log(`AlbumRepository: Filtering out album ${a.id} because owner ${a.ownerEmail} !== ${email}`);
+                const owner = a.ownerEmail || email; // Fallback to current email if owner missing (old format)
+                if (owner.toLowerCase() !== email.toLowerCase()) {
+                    DebugLogger.log('Album Filter Skip', `Filtering out album ${a.id} because owner ${owner} !== ${email}`);
                     needsIndexUpdate = true;
                     return false;
                 }
                 return true;
             });
-            console.log(`AlbumRepository: Found ${localAlbums.length} local albums after filtering`);
+            DebugLogger.log('Album Found', `Found ${localAlbums.length} local albums after filtering`);
 
             // Check if any local album in index has photoKeys (should be light)
             if (localAlbums.some(a => a.photoKeys !== undefined)) {
@@ -183,9 +182,9 @@ export class AlbumRepository implements IAlbumRepository {
 
         } catch (e: any) {
             if (e.name !== 'NoSuchKey' && e.$metadata?.httpStatusCode !== 404) {
-                console.error(`AlbumRepository: Failed to load index ${indexKey}, falling back to full listing`, e);
+                DebugLogger.error('Album Index Fetch', `Failed for ${indexKey}`, e);
             } else {
-                console.log(`AlbumRepository: Index ${indexKey} not found (404), falling back to full listing`);
+                DebugLogger.log('Album Index Missing', `404 for ${indexKey}, falling back to full listing`);
             }
 
             // 4. Fallback: Full Listing
@@ -239,7 +238,7 @@ export class AlbumRepository implements IAlbumRepository {
 
         // 7. Return combined list (with full photoKeys for shared if they were just discovered, or light if preferred)
         const combined = [...localAlbums, ...sharedAlbums];
-        console.log(`AlbumRepository: Returning ${combined.length} combined albums (${localAlbums.length} local, ${sharedAlbums.length} shared) for ${email}`);
+        DebugLogger.log('Albums Result', `Returning ${combined.length} albums (${localAlbums.length} local, ${sharedAlbums.length} shared) for ${email}`);
         return combined;
     })();
 

--- a/frontend/src/infra/album.repository.ts
+++ b/frontend/src/infra/album.repository.ts
@@ -1,7 +1,8 @@
-import type { IAlbumRepository, Album, IS3Repository } from '../domain/types';
+import type { IAlbumRepository, Album, IS3Repository, UploadedPhoto } from '../domain/types';
 import { encodeText, decodeText, uint8ArrayToBase64, limitConcurrency } from './utils';
 import { GlobalLock } from './locks';
 import * as Crypto from 'expo-crypto';
+import { Alert, Platform } from 'react-native';
 
 // Simple memory cache for albums index to speed up navigation
 export const albumsCache = new Map<string, { data: Album[], timestamp: number }>();
@@ -147,8 +148,18 @@ export class AlbumRepository implements IAlbumRepository {
             const indexData = await this.s3Repo.getFile(bucket, indexKey);
             const decoded = decodeText(indexData);
             console.log(`AlbumRepository: Loaded index ${indexKey}, length: ${decoded.length}`);
-            const albums = JSON.parse(decoded) as Album[];
+            let albums;
+            try {
+                albums = JSON.parse(decoded) as Album[];
+            } catch (err: any) {
+                console.error(`AlbumRepository: Failed to parse index JSON: ${decoded.substring(0, 100)}`, err);
+                if (Platform.OS === 'android') {
+                    Alert.alert('JSON Parse Error', `Failed to parse albums index: ${err.message}`);
+                }
+                throw err;
+            }
 
+            console.log(`AlbumRepository: Filtering ${albums.length} albums for email: ${email}`);
             localAlbums = albums.filter(a => {
                 if (!a.albumKey) {
                     console.warn(`AlbumRepository: Hiding incompatible old album ${a.id} from index`);
@@ -156,12 +167,14 @@ export class AlbumRepository implements IAlbumRepository {
                     return false;
                 }
                 // Only keep local albums in the local index
-                if (a.ownerEmail && a.ownerEmail !== email) {
+                if (a.ownerEmail && a.ownerEmail.toLowerCase() !== email.toLowerCase()) {
+                    console.log(`AlbumRepository: Filtering out album ${a.id} because owner ${a.ownerEmail} !== ${email}`);
                     needsIndexUpdate = true;
                     return false;
                 }
                 return true;
             });
+            console.log(`AlbumRepository: Found ${localAlbums.length} local albums after filtering`);
 
             // Check if any local album in index has photoKeys (should be light)
             if (localAlbums.some(a => a.photoKeys !== undefined)) {

--- a/frontend/src/infra/debug-logger.ts
+++ b/frontend/src/infra/debug-logger.ts
@@ -1,0 +1,47 @@
+class DebugLogger {
+    private static eventCounts = new Map<string, number>();
+    private static MAX_ALERTS = 10;
+
+    private static isReactNative(): boolean {
+        return typeof navigator !== 'undefined' && navigator.product === 'ReactNative';
+    }
+
+    static log(event: string, message: string) {
+        console.log(`[DEBUG] ${event}: ${message}`);
+
+        if (!this.isReactNative()) return;
+
+        try {
+            const { Alert, Platform } = require('react-native');
+            if (Platform.OS !== 'android') return;
+
+            const count = (this.eventCounts.get(event) || 0) + 1;
+            this.eventCounts.set(event, count);
+
+            if (count <= this.MAX_ALERTS) {
+                Alert.alert(`Debug #${count}: ${event}`, message);
+            }
+        } catch (e) {}
+    }
+
+    static error(event: string, message: string, error?: any) {
+        const errorMsg = error ? `${message} (${error.message || error})` : message;
+        console.error(`[DEBUG ERROR] ${event}: ${errorMsg}`, error);
+
+        if (!this.isReactNative()) return;
+
+        try {
+            const { Alert, Platform } = require('react-native');
+            if (Platform.OS !== 'android') return;
+
+            const count = (this.eventCounts.get(`${event}_err`) || 0) + 1;
+            this.eventCounts.set(`${event}_err`, count);
+
+            if (count <= this.MAX_ALERTS) {
+                Alert.alert(`Debug Error #${count}: ${event}`, errorMsg);
+            }
+        } catch (e) {}
+    }
+}
+
+export default DebugLogger;

--- a/frontend/src/infra/debug-logger.ts
+++ b/frontend/src/infra/debug-logger.ts
@@ -1,46 +1,72 @@
 class DebugLogger {
-    private static eventCounts = new Map<string, number>();
-    private static MAX_ALERTS = 10;
+    private static pendingMessages: string[] = [];
+    private static timer: any = null;
+    private static isShowing = false;
 
     private static isReactNative(): boolean {
         return typeof navigator !== 'undefined' && navigator.product === 'ReactNative';
     }
 
-    static log(event: string, message: string) {
-        console.log(`[DEBUG] ${event}: ${message}`);
-
-        if (!this.isReactNative()) return;
+    private static async showBuffer() {
+        if (this.pendingMessages.length === 0 || this.isShowing) return;
 
         try {
             const { Alert, Platform } = require('react-native');
-            if (Platform.OS !== 'android') return;
-
-            const count = (this.eventCounts.get(event) || 0) + 1;
-            this.eventCounts.set(event, count);
-
-            if (count <= this.MAX_ALERTS) {
-                Alert.alert(`Debug #${count}: ${event}`, message);
+            if (Platform.OS !== 'android') {
+                this.pendingMessages = [];
+                return;
             }
-        } catch (e) {}
+
+            this.isShowing = true;
+            const messages = [...this.pendingMessages];
+            this.pendingMessages = [];
+
+            const fullMessage = messages.join('\n\n');
+
+            await new Promise<void>((resolve) => {
+                Alert.alert(
+                    `Debug Summary (${messages.length} events)`,
+                    fullMessage,
+                    [{ text: 'OK', onPress: () => resolve() }],
+                    { onDismiss: () => resolve() }
+                );
+            });
+        } catch (e) {
+            console.error('DebugLogger failed to show alert', e);
+        } finally {
+            this.isShowing = false;
+            // Schedule next buffer check if messages arrived while showing
+            if (this.pendingMessages.length > 0) {
+                setTimeout(() => this.showBuffer(), 500);
+            }
+        }
+    }
+
+    private static queueMessage(level: string, event: string, message: string) {
+        const timestamp = new Date().toLocaleTimeString();
+        const formatted = `[${timestamp}] ${level} - ${event}: ${message}`;
+        this.pendingMessages.push(formatted);
+
+        // Keep buffer manageable
+        if (this.pendingMessages.length > 20) {
+            this.pendingMessages.shift();
+        }
+
+        if (!this.isReactNative()) return;
+
+        if (this.timer) clearTimeout(this.timer);
+        this.timer = setTimeout(() => this.showBuffer(), 1000);
+    }
+
+    static log(event: string, message: string) {
+        console.log(`[DEBUG] ${event}: ${message}`);
+        this.queueMessage('INFO', event, message);
     }
 
     static error(event: string, message: string, error?: any) {
         const errorMsg = error ? `${message} (${error.message || error})` : message;
         console.error(`[DEBUG ERROR] ${event}: ${errorMsg}`, error);
-
-        if (!this.isReactNative()) return;
-
-        try {
-            const { Alert, Platform } = require('react-native');
-            if (Platform.OS !== 'android') return;
-
-            const count = (this.eventCounts.get(`${event}_err`) || 0) + 1;
-            this.eventCounts.set(`${event}_err`, count);
-
-            if (count <= this.MAX_ALERTS) {
-                Alert.alert(`Debug Error #${count}: ${event}`, errorMsg);
-            }
-        } catch (e) {}
+        this.queueMessage('ERROR', event, errorMsg);
     }
 }
 

--- a/frontend/src/infra/s3.repository.ts
+++ b/frontend/src/infra/s3.repository.ts
@@ -267,11 +267,15 @@ export class S3Repository implements IS3Repository {
 
     const data = await this.s3.send(command);
     if (!data.Body) {
+      console.error(`S3: getFile ${key} failed - No body in response`);
       throw new Error('No body in S3 response');
     }
 
+    console.log(`S3: getFile ${key} body type: ${typeof data.Body}, constructor: ${(data.Body as any).constructor?.name}`);
+
     // Robust transformation: try transformToUint8Array first, then fallback to manual stream consumption
     if (typeof (data.Body as any).transformToUint8Array === 'function') {
+        console.log(`S3: using transformToUint8Array for ${key}`);
         const bytes = await (data.Body as any).transformToUint8Array();
         const result = new Uint8Array(bytes);
         if (isThumbnail) {
@@ -303,7 +307,8 @@ export class S3Repository implements IS3Repository {
     }
 
     // Handle Blob (common in React Native fetch)
-    if (data.Body && (typeof (data.Body as any).arrayBuffer === 'function' || data.Body instanceof Blob)) {
+    if (data.Body && (typeof (data.Body as any).arrayBuffer === 'function' || (typeof Blob !== 'undefined' && data.Body instanceof Blob))) {
+        console.log(`S3: using arrayBuffer/Blob conversion for ${key}`);
         let buffer: ArrayBuffer;
         if (typeof (data.Body as any).arrayBuffer === 'function') {
             buffer = await (data.Body as any).arrayBuffer();
@@ -312,7 +317,10 @@ export class S3Repository implements IS3Repository {
             buffer = await new Promise((resolve, reject) => {
                 const reader = new FileReader();
                 reader.onload = () => resolve(reader.result as ArrayBuffer);
-                reader.onerror = () => reject(new Error('Failed to read Blob as ArrayBuffer'));
+                reader.onerror = (e) => {
+                    console.error(`S3: FileReader error for ${key}`, e);
+                    reject(new Error('Failed to read Blob as ArrayBuffer'));
+                };
                 reader.readAsArrayBuffer(data.Body as Blob);
             });
         }

--- a/frontend/src/infra/s3.repository.ts
+++ b/frontend/src/infra/s3.repository.ts
@@ -302,6 +302,16 @@ export class S3Repository implements IS3Repository {
         return result;
     }
 
+    // Handle Blob (common in React Native fetch)
+    if (typeof (data.Body as any).arrayBuffer === 'function') {
+        const buffer = await (data.Body as any).arrayBuffer();
+        const result = new Uint8Array(buffer);
+        if (isThumbnail) {
+            ThumbnailCache.set(key, { data: result });
+        }
+        return result;
+    }
+
     // Last resort: if it's already a Uint8Array or similar
     if (data.Body instanceof Uint8Array) {
         const result = data.Body as Uint8Array;
@@ -311,7 +321,7 @@ export class S3Repository implements IS3Repository {
         return result;
     }
 
-    throw new Error('Unsupported S3 body type');
+    throw new Error(`Unsupported S3 body type: ${typeof data.Body}`);
   }
 
   async exists(bucket: string, key: string, customSSEKey?: string | null): Promise<boolean> {

--- a/frontend/src/infra/s3.repository.ts
+++ b/frontend/src/infra/s3.repository.ts
@@ -303,8 +303,19 @@ export class S3Repository implements IS3Repository {
     }
 
     // Handle Blob (common in React Native fetch)
-    if (typeof (data.Body as any).arrayBuffer === 'function') {
-        const buffer = await (data.Body as any).arrayBuffer();
+    if (data.Body && (typeof (data.Body as any).arrayBuffer === 'function' || data.Body instanceof Blob)) {
+        let buffer: ArrayBuffer;
+        if (typeof (data.Body as any).arrayBuffer === 'function') {
+            buffer = await (data.Body as any).arrayBuffer();
+        } else {
+            // Fallback for environments where Blob.arrayBuffer() is missing
+            buffer = await new Promise((resolve, reject) => {
+                const reader = new FileReader();
+                reader.onload = () => resolve(reader.result as ArrayBuffer);
+                reader.onerror = () => reject(new Error('Failed to read Blob as ArrayBuffer'));
+                reader.readAsArrayBuffer(data.Body as Blob);
+            });
+        }
         const result = new Uint8Array(buffer);
         if (isThumbnail) {
             ThumbnailCache.set(key, { data: result });

--- a/frontend/src/infra/s3.repository.ts
+++ b/frontend/src/infra/s3.repository.ts
@@ -13,6 +13,7 @@ import type { IS3Repository, S3Credentials, UploadedPhoto } from '../domain/type
 import { base64ToUint8Array, uint8ArrayToBase64, decodeText, md5Async } from './utils';
 import { ThumbnailCache } from './thumbnail-cache';
 import { Alert, Platform } from 'react-native';
+import DebugLogger from './debug-logger';
 
 // Cache S3 clients by credentials to reuse connection pools
 const s3Clients = new Map<string, S3Client>();
@@ -250,7 +251,6 @@ export class S3Repository implements IS3Repository {
   }
 
   async getFile(bucket: string, key: string, customSSEKey?: string | null): Promise<Uint8Array> {
-    console.log(`S3: getFile ${key} (SSE: ${customSSEKey ? 'yes' : 'no'})`);
     const isThumbnail = key.includes('/thumbnail/');
     if (isThumbnail && customSSEKey === undefined) {
         const cached = ThumbnailCache.get(key);
@@ -272,27 +272,28 @@ export class S3Repository implements IS3Repository {
     try {
         data = await this.s3.send(command);
     } catch (e: any) {
-        console.error(`S3: getFile ${key} request failed`, e);
-        if (Platform.OS === 'android') {
-            s3ErrorCount++;
-            Alert.alert(`S3 Error #${s3ErrorCount}`, `Failed to fetch ${key}: ${e.message}`);
-        }
+        DebugLogger.error('S3 Fetch', `Failed to fetch ${key}`, e);
         throw e;
     }
 
     if (!data.Body) {
-      console.error(`S3: getFile ${key} failed - No body in response`);
+      DebugLogger.error('S3 Body', `No body in response for ${key}`);
       throw new Error('No body in S3 response');
     }
 
     // Android/React Native body might be in data.Body._bodyBlob or similar if not standard
-    const body = (data.Body as any)._bodyBlob || data.Body;
+    const body = (data.Body as any)._bodyBlob || (data.Body as any).body || data.Body;
 
-    console.log(`S3: getFile ${key} body type: ${typeof body}, constructor: ${body.constructor?.name}`);
+    if (!isThumbnail) {
+        try {
+            DebugLogger.log('S3 Body Info', `${key}: type=${typeof body}, constructor=${body.constructor?.name}, keys=${Object.keys(data.Body).join(',')}`);
+        } catch (e) {
+            DebugLogger.log('S3 Body Info', `${key}: type=${typeof body}`);
+        }
+    }
 
     // Robust transformation: try transformToUint8Array first, then fallback to manual stream consumption
     if (typeof (body as any).transformToUint8Array === 'function') {
-        console.log(`S3: using transformToUint8Array for ${key}`);
         const bytes = await (body as any).transformToUint8Array();
         const result = new Uint8Array(bytes);
         if (isThumbnail) {
@@ -343,11 +344,7 @@ export class S3Repository implements IS3Repository {
                 });
             }
         } catch (err: any) {
-            console.error(`S3: arrayBuffer/Blob conversion failed for ${key}`, err);
-            if (Platform.OS === 'android') {
-                s3ErrorCount++;
-                Alert.alert(`S3 Transform Error #${s3ErrorCount}`, `Failed to transform ${key}: ${err.message}`);
-            }
+            DebugLogger.error('S3 Transform', `Failed to transform ${key}`, err);
             throw err;
         }
         const result = new Uint8Array(buffer);
@@ -366,11 +363,7 @@ export class S3Repository implements IS3Repository {
         return result;
     }
 
-    console.error(`Unsupported S3 body type for ${key}: ${typeof body}`);
-    if (Platform.OS === 'android') {
-        s3ErrorCount++;
-        Alert.alert(`S3 Body Error #${s3ErrorCount}`, `Unsupported body type for ${key}: ${typeof body}`);
-    }
+    DebugLogger.error('S3 Body Type', `Unsupported body type for ${key}: ${typeof body}`);
     throw new Error(`Unsupported S3 body type: ${typeof body}`);
   }
 

--- a/frontend/src/infra/s3.repository.ts
+++ b/frontend/src/infra/s3.repository.ts
@@ -10,11 +10,14 @@ import {
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import type { IS3Repository, S3Credentials, UploadedPhoto } from '../domain/types';
-import { base64ToUint8Array, uint8ArrayToBase64, decodeText, md5 } from './utils';
+import { base64ToUint8Array, uint8ArrayToBase64, decodeText, md5Async } from './utils';
 import { ThumbnailCache } from './thumbnail-cache';
+import { Alert, Platform } from 'react-native';
 
 // Cache S3 clients by credentials to reuse connection pools
 const s3Clients = new Map<string, S3Client>();
+
+let s3ErrorCount = 0;
 
 export class S3Repository implements IS3Repository {
   private s3: S3Client;
@@ -44,7 +47,7 @@ export class S3Repository implements IS3Repository {
     if (customKey === null) return null;
     if (customKey) {
         const binaryKey = base64ToUint8Array(customKey);
-        const hash = md5(binaryKey);
+        const hash = await md5Async(binaryKey);
         const keyMD5 = uint8ArrayToBase64(hash);
         return {
             algorithm: 'AES256',
@@ -59,7 +62,7 @@ export class S3Repository implements IS3Repository {
     const binaryKey = base64ToUint8Array(key);
 
     // Compute MD5 of the binary key using our cross-platform utility
-    const hash = md5(binaryKey);
+    const hash = await md5Async(binaryKey);
 
     const keyMD5 = uint8ArrayToBase64(hash);
 
@@ -265,18 +268,32 @@ export class S3Repository implements IS3Repository {
       } : {}),
     });
 
-    const data = await this.s3.send(command);
+    let data;
+    try {
+        data = await this.s3.send(command);
+    } catch (e: any) {
+        console.error(`S3: getFile ${key} request failed`, e);
+        if (Platform.OS === 'android') {
+            s3ErrorCount++;
+            Alert.alert(`S3 Error #${s3ErrorCount}`, `Failed to fetch ${key}: ${e.message}`);
+        }
+        throw e;
+    }
+
     if (!data.Body) {
       console.error(`S3: getFile ${key} failed - No body in response`);
       throw new Error('No body in S3 response');
     }
 
-    console.log(`S3: getFile ${key} body type: ${typeof data.Body}, constructor: ${(data.Body as any).constructor?.name}`);
+    // Android/React Native body might be in data.Body._bodyBlob or similar if not standard
+    const body = (data.Body as any)._bodyBlob || data.Body;
+
+    console.log(`S3: getFile ${key} body type: ${typeof body}, constructor: ${body.constructor?.name}`);
 
     // Robust transformation: try transformToUint8Array first, then fallback to manual stream consumption
-    if (typeof (data.Body as any).transformToUint8Array === 'function') {
+    if (typeof (body as any).transformToUint8Array === 'function') {
         console.log(`S3: using transformToUint8Array for ${key}`);
-        const bytes = await (data.Body as any).transformToUint8Array();
+        const bytes = await (body as any).transformToUint8Array();
         const result = new Uint8Array(bytes);
         if (isThumbnail) {
             ThumbnailCache.set(key, { data: result });
@@ -285,7 +302,7 @@ export class S3Repository implements IS3Repository {
     }
 
     // Fallback for environments where transformToUint8Array is not available (e.g. some browser versions)
-    const reader = (data.Body as any).getReader ? (data.Body as any).getReader() : null;
+    const reader = (body as any).getReader ? (body as any).getReader() : null;
     if (reader) {
         const chunks: Uint8Array[] = [];
         while (true) {
@@ -307,22 +324,31 @@ export class S3Repository implements IS3Repository {
     }
 
     // Handle Blob (common in React Native fetch)
-    if (data.Body && (typeof (data.Body as any).arrayBuffer === 'function' || (typeof Blob !== 'undefined' && data.Body instanceof Blob))) {
+    if (body && (typeof (body as any).arrayBuffer === 'function' || (typeof Blob !== 'undefined' && body instanceof Blob))) {
         console.log(`S3: using arrayBuffer/Blob conversion for ${key}`);
         let buffer: ArrayBuffer;
-        if (typeof (data.Body as any).arrayBuffer === 'function') {
-            buffer = await (data.Body as any).arrayBuffer();
-        } else {
-            // Fallback for environments where Blob.arrayBuffer() is missing
-            buffer = await new Promise((resolve, reject) => {
-                const reader = new FileReader();
-                reader.onload = () => resolve(reader.result as ArrayBuffer);
-                reader.onerror = (e) => {
-                    console.error(`S3: FileReader error for ${key}`, e);
-                    reject(new Error('Failed to read Blob as ArrayBuffer'));
-                };
-                reader.readAsArrayBuffer(data.Body as Blob);
-            });
+        try {
+            if (typeof (body as any).arrayBuffer === 'function') {
+                buffer = await (body as any).arrayBuffer();
+            } else {
+                // Fallback for environments where Blob.arrayBuffer() is missing
+                buffer = await new Promise((resolve, reject) => {
+                    const reader = new FileReader();
+                    reader.onload = () => resolve(reader.result as ArrayBuffer);
+                    reader.onerror = (e) => {
+                        console.error(`S3: FileReader error for ${key}`, e);
+                        reject(new Error('Failed to read Blob as ArrayBuffer'));
+                    };
+                    reader.readAsArrayBuffer(body as Blob);
+                });
+            }
+        } catch (err: any) {
+            console.error(`S3: arrayBuffer/Blob conversion failed for ${key}`, err);
+            if (Platform.OS === 'android') {
+                s3ErrorCount++;
+                Alert.alert(`S3 Transform Error #${s3ErrorCount}`, `Failed to transform ${key}: ${err.message}`);
+            }
+            throw err;
         }
         const result = new Uint8Array(buffer);
         if (isThumbnail) {
@@ -332,15 +358,20 @@ export class S3Repository implements IS3Repository {
     }
 
     // Last resort: if it's already a Uint8Array or similar
-    if (data.Body instanceof Uint8Array) {
-        const result = data.Body as Uint8Array;
+    if (body instanceof Uint8Array) {
+        const result = body as Uint8Array;
         if (isThumbnail) {
             ThumbnailCache.set(key, { data: result });
         }
         return result;
     }
 
-    throw new Error(`Unsupported S3 body type: ${typeof data.Body}`);
+    console.error(`Unsupported S3 body type for ${key}: ${typeof body}`);
+    if (Platform.OS === 'android') {
+        s3ErrorCount++;
+        Alert.alert(`S3 Body Error #${s3ErrorCount}`, `Unsupported body type for ${key}: ${typeof body}`);
+    }
+    throw new Error(`Unsupported S3 body type: ${typeof body}`);
   }
 
   async exists(bucket: string, key: string, customSSEKey?: string | null): Promise<boolean> {

--- a/frontend/src/infra/s3.repository.ts
+++ b/frontend/src/infra/s3.repository.ts
@@ -12,7 +12,6 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import type { IS3Repository, S3Credentials, UploadedPhoto } from '../domain/types';
 import { base64ToUint8Array, uint8ArrayToBase64, decodeText, md5Async } from './utils';
 import { ThumbnailCache } from './thumbnail-cache';
-import { Alert, Platform } from 'react-native';
 import DebugLogger from './debug-logger';
 
 // Cache S3 clients by credentials to reuse connection pools
@@ -250,6 +249,18 @@ export class S3Repository implements IS3Repository {
     await this.s3.send(command);
   }
 
+  private isAndroid(): boolean {
+      if (typeof navigator !== 'undefined' && navigator.product === 'ReactNative') {
+          try {
+              const { Platform } = require('react-native');
+              return Platform.OS === 'android';
+          } catch (e) {
+              return false;
+          }
+      }
+      return false;
+  }
+
   async getFile(bucket: string, key: string, customSSEKey?: string | null): Promise<Uint8Array> {
     const isThumbnail = key.includes('/thumbnail/');
     if (isThumbnail && customSSEKey === undefined) {
@@ -258,6 +269,29 @@ export class S3Repository implements IS3Repository {
     }
 
     const sse = await this.getSSE(customSSEKey);
+
+    if (this.isAndroid()) {
+        try {
+            // Direct fetch bypasses ChecksumStream Blob issue
+            const url = await this.getDownloadUrl(bucket, key, customSSEKey);
+            const response = await fetch(url);
+            if (!response.ok) throw new Error(`Fetch failed with status ${response.status}`);
+            const blob = await response.blob();
+            const result = await new Promise<Uint8Array>((resolve, reject) => {
+                const reader = new FileReader();
+                reader.onload = () => resolve(new Uint8Array(reader.result as ArrayBuffer));
+                reader.onerror = () => reject(new Error('Failed to read response as ArrayBuffer'));
+                reader.readAsArrayBuffer(blob);
+            });
+            if (isThumbnail) {
+                ThumbnailCache.set(key, { data: result });
+            }
+            return result;
+        } catch (e) {
+            DebugLogger.error('Android Fetch', `Failed for ${key}, falling back to SDK`, e);
+        }
+    }
+
     const command = new GetObjectCommand({
       Bucket: bucket,
       Key: key,

--- a/frontend/src/infra/s3.repository.ts
+++ b/frontend/src/infra/s3.repository.ts
@@ -274,8 +274,18 @@ export class S3Repository implements IS3Repository {
         try {
             // Direct fetch bypasses ChecksumStream Blob issue
             const url = await this.getDownloadUrl(bucket, key, customSSEKey);
-            const response = await fetch(url);
-            if (!response.ok) throw new Error(`Fetch failed with status ${response.status}`);
+            const headers: Record<string, string> = {};
+            if (sse) {
+                headers['x-amz-server-side-encryption-customer-algorithm'] = sse.algorithm;
+                headers['x-amz-server-side-encryption-customer-key'] = sse.key;
+                headers['x-amz-server-side-encryption-customer-key-MD5'] = sse.keyMD5;
+            }
+
+            const response = await fetch(url, { headers });
+            if (!response.ok) {
+                const text = await response.text().catch(() => 'no body');
+                throw new Error(`Fetch failed with status ${response.status}: ${text}`);
+            }
             const blob = await response.blob();
             const result = await new Promise<Uint8Array>((resolve, reject) => {
                 const reader = new FileReader();
@@ -318,7 +328,7 @@ export class S3Repository implements IS3Repository {
     // Android/React Native body might be in data.Body._bodyBlob or similar if not standard
     const body = (data.Body as any)._bodyBlob || (data.Body as any).body || data.Body;
 
-    if (!isThumbnail) {
+    if (!isThumbnail && this.isAndroid()) {
         try {
             DebugLogger.log('S3 Body Info', `${key}: type=${typeof body}, constructor=${body.constructor?.name}, keys=${Object.keys(data.Body).join(',')}`);
         } catch (e) {

--- a/frontend/src/infra/utils.ts
+++ b/frontend/src/infra/utils.ts
@@ -3,6 +3,9 @@ import SparkMD5 from 'spark-md5';
 const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
 
 export function uint8ArrayToBase64(bytes: Uint8Array): string {
+  if (typeof Buffer !== 'undefined') {
+      return Buffer.from(bytes).toString('base64');
+  }
   let result = '';
   const len = bytes.length;
   for (let i = 0; i < len; i += 3) {
@@ -46,6 +49,10 @@ export function md5Hex(data: Uint8Array): string {
 }
 
 export function base64ToUint8Array(base64: string): Uint8Array {
+  if (typeof Buffer !== 'undefined') {
+      const buf = Buffer.from(base64, 'base64');
+      return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+  }
   const binaryString = base64.replace(/=/g, '');
   const len = binaryString.length;
   const bytes = new Uint8Array(Math.floor((len * 3) / 4));

--- a/frontend/src/infra/utils.ts
+++ b/frontend/src/infra/utils.ts
@@ -75,9 +75,10 @@ export async function md5Async(data: Uint8Array): Promise<Uint8Array> {
     }
     try {
         const Crypto = require('expo-crypto');
+        const buffer = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
         const arrayBuffer = await Crypto.digest(
             Crypto.CryptoDigestAlgorithm.MD5,
-            data.buffer as ArrayBuffer
+            buffer as ArrayBuffer
         );
         return new Uint8Array(arrayBuffer);
     } catch (e) {
@@ -92,9 +93,10 @@ export async function md5HexAsync(data: Uint8Array): Promise<string> {
     }
     try {
         const Crypto = require('expo-crypto');
+        const buffer = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
         const arrayBuffer = await Crypto.digest(
             Crypto.CryptoDigestAlgorithm.MD5,
-            data.buffer as ArrayBuffer
+            buffer as ArrayBuffer
         );
         const bytes = new Uint8Array(arrayBuffer);
         let hex = '';

--- a/frontend/src/infra/utils.ts
+++ b/frontend/src/infra/utils.ts
@@ -36,9 +36,13 @@ export async function limitConcurrency<T>(tasks: (() => Promise<T>)[], limit: nu
 
 export function md5(data: Uint8Array): Uint8Array {
     if (typeof Buffer !== 'undefined') {
-        const crypto = require('crypto');
-        const hash = crypto.createHash('md5').update(Buffer.from(data)).digest();
-        return new Uint8Array(hash);
+        try {
+            const crypto = require('crypto');
+            const hash = crypto.createHash('md5').update(Buffer.from(data)).digest();
+            return new Uint8Array(hash);
+        } catch (e) {
+            console.warn('Crypto module not available, falling back to manual MD5', e);
+        }
     }
     const hashHex = md5Hex(data);
     const result = new Uint8Array(hashHex.length / 2);
@@ -50,8 +54,12 @@ export function md5(data: Uint8Array): Uint8Array {
 
 export function md5Hex(data: Uint8Array): string {
     if (typeof Buffer !== 'undefined') {
-        const crypto = require('crypto');
-        return crypto.createHash('md5').update(Buffer.from(data)).digest('hex');
+        try {
+            const crypto = require('crypto');
+            return crypto.createHash('md5').update(Buffer.from(data)).digest('hex');
+        } catch (e) {
+            console.warn('Crypto module not available, falling back to SparkMD5', e);
+        }
     }
     const buffer = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
     return SparkMD5.ArrayBuffer.hash(buffer as any);

--- a/frontend/src/infra/utils.ts
+++ b/frontend/src/infra/utils.ts
@@ -1,4 +1,5 @@
 import SparkMD5 from 'spark-md5';
+import * as Crypto from 'expo-crypto';
 
 const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
 
@@ -41,7 +42,7 @@ export function md5(data: Uint8Array): Uint8Array {
             const hash = crypto.createHash('md5').update(Buffer.from(data)).digest();
             return new Uint8Array(hash);
         } catch (e) {
-            console.warn('Crypto module not available, falling back to manual MD5', e);
+            console.warn('Crypto module not available, falling back to SparkMD5', e);
         }
     }
     const hashHex = md5Hex(data);
@@ -63,6 +64,23 @@ export function md5Hex(data: Uint8Array): string {
     }
     const buffer = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
     return SparkMD5.ArrayBuffer.hash(buffer as any);
+}
+
+export async function md5Async(data: Uint8Array): Promise<Uint8Array> {
+    const base64 = await Crypto.digestAsync(
+        Crypto.CryptoDigestAlgorithm.MD5,
+        data,
+        { encoding: Crypto.CryptoEncoding.BASE64 }
+    );
+    return base64ToUint8Array(base64);
+}
+
+export async function md5HexAsync(data: Uint8Array): Promise<string> {
+    return await Crypto.digestAsync(
+        Crypto.CryptoDigestAlgorithm.MD5,
+        data,
+        { encoding: Crypto.CryptoEncoding.HEX }
+    );
 }
 
 export function base64ToUint8Array(base64: string): Uint8Array {

--- a/frontend/src/infra/utils.ts
+++ b/frontend/src/infra/utils.ts
@@ -1,7 +1,10 @@
 import SparkMD5 from 'spark-md5';
-import * as Crypto from 'expo-crypto';
 
 const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
+function isReactNative(): boolean {
+    return typeof navigator !== 'undefined' && navigator.product === 'ReactNative';
+}
 
 export function uint8ArrayToBase64(bytes: Uint8Array): string {
   if (typeof Buffer !== 'undefined') {
@@ -67,20 +70,42 @@ export function md5Hex(data: Uint8Array): string {
 }
 
 export async function md5Async(data: Uint8Array): Promise<Uint8Array> {
-    const base64 = await Crypto.digestAsync(
-        Crypto.CryptoDigestAlgorithm.MD5,
-        data,
-        { encoding: Crypto.CryptoEncoding.BASE64 }
-    );
-    return base64ToUint8Array(base64);
+    if (!isReactNative()) {
+        return md5(data);
+    }
+    try {
+        const Crypto = require('expo-crypto');
+        const arrayBuffer = await Crypto.digest(
+            Crypto.CryptoDigestAlgorithm.MD5,
+            data.buffer as ArrayBuffer
+        );
+        return new Uint8Array(arrayBuffer);
+    } catch (e) {
+        console.warn('Crypto.digest failed, falling back to SparkMD5', e);
+        return md5(data);
+    }
 }
 
 export async function md5HexAsync(data: Uint8Array): Promise<string> {
-    return await Crypto.digestAsync(
-        Crypto.CryptoDigestAlgorithm.MD5,
-        data,
-        { encoding: Crypto.CryptoEncoding.HEX }
-    );
+    if (!isReactNative()) {
+        return md5Hex(data);
+    }
+    try {
+        const Crypto = require('expo-crypto');
+        const arrayBuffer = await Crypto.digest(
+            Crypto.CryptoDigestAlgorithm.MD5,
+            data.buffer as ArrayBuffer
+        );
+        const bytes = new Uint8Array(arrayBuffer);
+        let hex = '';
+        for (let i = 0; i < bytes.length; i++) {
+            hex += bytes[i].toString(16).padStart(2, '0');
+        }
+        return hex;
+    } catch (e) {
+        console.warn('Crypto.digest (hex) failed, falling back to SparkMD5', e);
+        return md5Hex(data);
+    }
 }
 
 export function base64ToUint8Array(base64: string): Uint8Array {

--- a/frontend/src/infra/utils.ts
+++ b/frontend/src/infra/utils.ts
@@ -35,17 +35,26 @@ export async function limitConcurrency<T>(tasks: (() => Promise<T>)[], limit: nu
 }
 
 export function md5(data: Uint8Array): Uint8Array {
-  const hashHex = md5Hex(data);
-  const result = new Uint8Array(hashHex.length / 2);
-  for (let i = 0; i < hashHex.length; i += 2) {
-    result[i / 2] = parseInt(hashHex.substring(i, i + 2), 16);
-  }
-  return result;
+    if (typeof Buffer !== 'undefined') {
+        const crypto = require('crypto');
+        const hash = crypto.createHash('md5').update(Buffer.from(data)).digest();
+        return new Uint8Array(hash);
+    }
+    const hashHex = md5Hex(data);
+    const result = new Uint8Array(hashHex.length / 2);
+    for (let i = 0; i < hashHex.length; i += 2) {
+        result[i / 2] = parseInt(hashHex.substring(i, i + 2), 16);
+    }
+    return result;
 }
 
 export function md5Hex(data: Uint8Array): string {
-  const buffer = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
-  return SparkMD5.ArrayBuffer.hash(buffer as any);
+    if (typeof Buffer !== 'undefined') {
+        const crypto = require('crypto');
+        return crypto.createHash('md5').update(Buffer.from(data)).digest('hex');
+    }
+    const buffer = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
+    return SparkMD5.ArrayBuffer.hash(buffer as any);
 }
 
 export function base64ToUint8Array(base64: string): Uint8Array {
@@ -76,6 +85,9 @@ export function base64ToUint8Array(base64: string): Uint8Array {
 }
 
 export function encodeText(text: string): Uint8Array {
+  if (typeof Buffer !== 'undefined') {
+      return new Uint8Array(Buffer.from(text, 'utf-8'));
+  }
   if (typeof TextEncoder !== 'undefined') {
     return new TextEncoder().encode(text);
   }
@@ -88,6 +100,9 @@ export function encodeText(text: string): Uint8Array {
 }
 
 export function decodeText(bytes: Uint8Array): string {
+  if (typeof Buffer !== 'undefined') {
+      return Buffer.from(bytes).toString('utf-8');
+  }
   if (typeof TextDecoder !== 'undefined') {
     return new TextDecoder().decode(bytes);
   }

--- a/frontend/src/react/components/PhotoItem.tsx
+++ b/frontend/src/react/components/PhotoItem.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { View, StyleSheet, ActivityIndicator, Image, Platform, TouchableOpacity, Alert } from 'react-native';
 import { Text } from 'react-native-paper';
 import { Circle, Check } from 'lucide-react-native';
+import { File, Directory, Paths } from 'expo-file-system';
 import { S3Repository } from '../../infra/s3.repository';
 import type { S3Credentials, Photo } from '../../domain/types';
 import { uint8ArrayToBase64 } from '../../infra/utils';
@@ -85,8 +86,25 @@ export const PhotoItem = React.memo(({
                   if (Platform.OS === 'web') {
                       const blob = new Blob([data as any], { type: 'image/jpeg' });
                       displayUrl = URL.createObjectURL(blob);
+                  } else if (Platform.OS === 'android') {
+                      // On Android, writing to a temp file is more reliable and memory-efficient than large base64 strings
+                      try {
+                          const tempDir = new Directory(Paths.cache, 'photos');
+                          if (!tempDir.exists) {
+                              tempDir.create();
+                          }
+                          const filename = photo.key.split('/').pop()!.replace('.enc', '.jpg');
+                          const tempFile = new File(tempDir, filename);
+                          const bytes = data instanceof Uint8Array ? data : new Uint8Array(data);
+                          tempFile.write(bytes);
+                          displayUrl = tempFile.uri;
+                      } catch (err: any) {
+                          console.error('Failed to write temp photo file on Android', err);
+                          // Fallback to base64 if temp file fails
+                          const bytes = data instanceof Uint8Array ? data : new Uint8Array(data);
+                          displayUrl = `data:image/jpeg;base64,${uint8ArrayToBase64(bytes)}`;
+                      }
                   } else {
-                      // On Android, ensure we have a proper Uint8Array before converting to base64
                       const bytes = data instanceof Uint8Array ? data : new Uint8Array(data);
                       const base64 = uint8ArrayToBase64(bytes);
                       displayUrl = `data:image/jpeg;base64,${base64}`;

--- a/frontend/src/react/components/PhotoItem.tsx
+++ b/frontend/src/react/components/PhotoItem.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { View, StyleSheet, ActivityIndicator, Image, Platform, TouchableOpacity } from 'react-native';
+import { View, StyleSheet, ActivityIndicator, Image, Platform, TouchableOpacity, Alert } from 'react-native';
 import { Text } from 'react-native-paper';
 import { Circle, Check } from 'lucide-react-native';
 import { S3Repository } from '../../infra/s3.repository';
@@ -96,8 +96,14 @@ export const PhotoItem = React.memo(({
                   }
                   setUrl(displayUrl);
               }
-          } catch (err) {
+          } catch (err: any) {
               console.error('Failed to load cloud image', err);
+              if (Platform.OS === 'android') {
+                  // Alert the error only once to avoid spamming the user if multiple photos fail.
+                  // But we use a ref to track if we already alerted.
+                  // Actually, better to just log or use a toast, but user asked for visibility.
+                  // Let's keep it simple for now, maybe only alert if it's a specific "Unsupported Body type" or "SSE" error
+              }
               if (isMounted) setError(true);
           }
       };

--- a/frontend/src/react/components/PhotoItem.tsx
+++ b/frontend/src/react/components/PhotoItem.tsx
@@ -86,7 +86,9 @@ export const PhotoItem = React.memo(({
                       const blob = new Blob([data as any], { type: 'image/jpeg' });
                       displayUrl = URL.createObjectURL(blob);
                   } else {
-                      const base64 = uint8ArrayToBase64(data);
+                      // On Android, ensure we have a proper Uint8Array before converting to base64
+                      const bytes = data instanceof Uint8Array ? data : new Uint8Array(data);
+                      const base64 = uint8ArrayToBase64(bytes);
                       displayUrl = `data:image/jpeg;base64,${base64}`;
                   }
 

--- a/frontend/src/react/components/PhotoItem.tsx
+++ b/frontend/src/react/components/PhotoItem.tsx
@@ -7,6 +7,7 @@ import { S3Repository } from '../../infra/s3.repository';
 import type { S3Credentials, Photo } from '../../domain/types';
 import { uint8ArrayToBase64 } from '../../infra/utils';
 import { ThumbnailCache } from '../../infra/thumbnail-cache';
+import DebugLogger from '../../infra/debug-logger';
 
 export const PhotoItem = React.memo(({
     photo,
@@ -89,17 +90,23 @@ export const PhotoItem = React.memo(({
                   } else if (Platform.OS === 'android') {
                       // On Android, writing to a temp file is more reliable and memory-efficient than large base64 strings
                       try {
+                          if (typeof Buffer === 'undefined') {
+                              DebugLogger.error('Polyfill', 'Buffer is undefined in PhotoItem');
+                          }
                           const tempDir = new Directory(Paths.cache, 'photos');
                           if (!tempDir.exists) {
-                              tempDir.create();
+                              tempDir.create({ intermediates: true, idempotent: true });
                           }
                           const filename = photo.key.split('/').pop()!.replace('.enc', '.jpg');
                           const tempFile = new File(tempDir, filename);
                           const bytes = data instanceof Uint8Array ? data : new Uint8Array(data);
                           tempFile.write(bytes);
                           displayUrl = tempFile.uri;
+                          if (photo.key.includes('original')) {
+                              DebugLogger.log('Photo Saved', `Saved ${photo.key} to ${displayUrl} (size: ${bytes.length})`);
+                          }
                       } catch (err: any) {
-                          console.error('Failed to write temp photo file on Android', err);
+                          DebugLogger.error('Photo Write', `Failed for ${photo.key}`, err);
                           // Fallback to base64 if temp file fails
                           const bytes = data instanceof Uint8Array ? data : new Uint8Array(data);
                           displayUrl = `data:image/jpeg;base64,${uint8ArrayToBase64(bytes)}`;
@@ -117,13 +124,7 @@ export const PhotoItem = React.memo(({
                   setUrl(displayUrl);
               }
           } catch (err: any) {
-              console.error('Failed to load cloud image', err);
-              if (Platform.OS === 'android') {
-                  // Alert the error only once to avoid spamming the user if multiple photos fail.
-                  // But we use a ref to track if we already alerted.
-                  // Actually, better to just log or use a toast, but user asked for visibility.
-                  // Let's keep it simple for now, maybe only alert if it's a specific "Unsupported Body type" or "SSE" error
-              }
+              DebugLogger.error('Photo Load', `Failed for ${photo.key}`, err);
               if (isMounted) setError(true);
           }
       };

--- a/frontend/src/react/hooks/useUpload.ts
+++ b/frontend/src/react/hooks/useUpload.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { Alert, Platform } from 'react-native';
 import * as DocumentPicker from 'expo-document-picker';
+import * as FileSystem from 'expo-file-system';
 import { S3Repository } from '../../infra/s3.repository';
 import { LocalGalleryRepository } from '../../infra/local-gallery.repository';
 import { UploadUseCase } from '../../usecase/upload.usecase';
@@ -44,7 +45,12 @@ export const useUpload = (creds: S3Credentials | null, email: string | null) => 
 
           try {
                         let creationDate: number | undefined;
-              if (asset.file) {
+              if (Platform.OS !== 'web' && (asset.uri.startsWith('file://') || asset.uri.startsWith('content://'))) {
+                const base64 = await FileSystem.readAsStringAsync(asset.uri, { encoding: 'base64' as any });
+                const binary = Buffer.from(base64, 'base64');
+                const result = ExifParserFactory.create(binary.buffer).parse();
+                creationDate = result.tags?.CreateDate ? new Date(result.tags.CreateDate * 1000).getTime() / 1000 : new Date().getTime() / 1000;
+              } else if (asset.file) {
                 const bytes = await asset.file.bytes()
                 const result = ExifParserFactory.create(bytes.buffer).parse();
                 creationDate = result.tags?.CreateDate ? new Date(result.tags.CreateDate * 1000).getTime() / 1000 : new Date().getTime() / 1000;

--- a/frontend/src/react/hooks/useUpload.ts
+++ b/frontend/src/react/hooks/useUpload.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import { Alert, Platform } from 'react-native';
 import * as DocumentPicker from 'expo-document-picker';
 import { S3Repository } from '../../infra/s3.repository';
 import { LocalGalleryRepository } from '../../infra/local-gallery.repository';
@@ -57,8 +58,11 @@ export const useUpload = (creds: S3Credentials | null, email: string | null) => 
             }
             // Give the UI thread more time to breathe between heavy image manipulations
             await new Promise(resolve => setTimeout(resolve, 300));
-          } catch (e) {
+          } catch (e: any) {
             console.error(`Failed to upload ${asset.name}`, e);
+            if (Platform.OS === 'android') {
+                Alert.alert('Upload Error', `Failed to upload ${asset.name}: ${e.message}`);
+            }
             // Continue with other assets
           } finally {
             current++;
@@ -76,6 +80,9 @@ export const useUpload = (creds: S3Credentials | null, email: string | null) => 
       return true; // Success
     } catch (err: any) {
       console.error('Upload error:', err);
+      if (Platform.OS === 'android') {
+          Alert.alert('General Upload Error', err.message || 'Failed to start upload');
+      }
       setError(err.message || 'Failed to upload photo');
       return false;
     } finally {

--- a/frontend/src/react/hooks/useUpload.ts
+++ b/frontend/src/react/hooks/useUpload.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react';
 import { Alert, Platform } from 'react-native';
 import * as DocumentPicker from 'expo-document-picker';
-import * as FileSystem from 'expo-file-system';
+import { File } from 'expo-file-system';
 import { S3Repository } from '../../infra/s3.repository';
 import { LocalGalleryRepository } from '../../infra/local-gallery.repository';
 import { UploadUseCase } from '../../usecase/upload.usecase';
@@ -46,9 +46,8 @@ export const useUpload = (creds: S3Credentials | null, email: string | null) => 
           try {
                         let creationDate: number | undefined;
               if (Platform.OS !== 'web' && (asset.uri.startsWith('file://') || asset.uri.startsWith('content://'))) {
-                const base64 = await FileSystem.readAsStringAsync(asset.uri, { encoding: 'base64' as any });
-                const binary = Buffer.from(base64, 'base64');
-                const result = ExifParserFactory.create(binary.buffer).parse();
+                const bytes = await new File(asset.uri).bytes();
+                const result = ExifParserFactory.create(bytes.buffer).parse();
                 creationDate = result.tags?.CreateDate ? new Date(result.tags.CreateDate * 1000).getTime() / 1000 : new Date().getTime() / 1000;
               } else if (asset.file) {
                 const bytes = await asset.file.bytes()

--- a/frontend/src/usecase/__tests__/upload.usecase.test.ts
+++ b/frontend/src/usecase/__tests__/upload.usecase.test.ts
@@ -7,6 +7,11 @@ jest.mock('expo-media-library', () => ({
   getAssetInfoAsync: jest.fn(),
 }));
 
+jest.mock('expo-file-system', () => ({
+  readAsStringAsync: jest.fn(),
+  EncodingType: { Base64: 'base64' }
+}));
+
 jest.mock('react-native', () => ({
   Platform: { OS: 'web' },
 }));

--- a/frontend/src/usecase/upload.usecase.ts
+++ b/frontend/src/usecase/upload.usecase.ts
@@ -3,7 +3,7 @@ import * as MediaLibrary from 'expo-media-library';
 import { File } from 'expo-file-system';
 import { Platform } from 'react-native';
 import { IS3Repository, ILocalGalleryRepository, S3Credentials, UploadedPhoto } from '../domain/types';
-import { encodeText, decodeText, md5Hex } from '../infra/utils';
+import { encodeText, decodeText, md5HexAsync } from '../infra/utils';
 import { GlobalLock } from '../infra/locks';
 
 export class UploadUseCase {
@@ -26,7 +26,7 @@ export class UploadUseCase {
     // 1. Process images
     const originalData = await this.uriToUint8Array(uri);
 
-    const hash = md5Hex(originalData);
+    const hash = await md5HexAsync(originalData);
 
     // Check if already exists in local cache (synced with cloud)
     if (await this.localRepo.existsById(hash)) {

--- a/frontend/src/usecase/upload.usecase.ts
+++ b/frontend/src/usecase/upload.usecase.ts
@@ -134,17 +134,19 @@ export class UploadUseCase {
   }
 
   private async uriToUint8Array(uri: string): Promise<Uint8Array> {
-    if (Platform.OS !== 'web' && (uri.startsWith('file://') || uri.startsWith('content://'))) {
+    if (Platform.OS !== 'web' && (uri.startsWith('file:') || uri.startsWith('content:'))) {
         try {
             const base64 = await FileSystem.readAsStringAsync(uri, { encoding: 'base64' as any });
-            const binary = Buffer.from(base64, 'base64');
-            return new Uint8Array(binary);
-        } catch (e) {
-            console.error('Failed to read local file with FileSystem', e);
-            // Fallback to fetch
+            return new Uint8Array(Buffer.from(base64, 'base64'));
+        } catch (e: any) {
+            console.error(`Failed to read local file with FileSystem: ${uri}`, e);
+            throw new Error(`Failed to read local file: ${e.message}`);
         }
     }
     const response = await fetch(uri);
+    if (!response.ok) {
+        throw new Error(`Failed to fetch URI: ${uri} (status: ${response.status})`);
+    }
     const buffer = await response.arrayBuffer();
     return new Uint8Array(buffer);
   }

--- a/frontend/src/usecase/upload.usecase.ts
+++ b/frontend/src/usecase/upload.usecase.ts
@@ -1,6 +1,6 @@
 import * as ImageManipulator from 'expo-image-manipulator';
 import * as MediaLibrary from 'expo-media-library';
-import * as FileSystem from 'expo-file-system';
+import { File } from 'expo-file-system';
 import { Platform } from 'react-native';
 import { IS3Repository, ILocalGalleryRepository, S3Credentials, UploadedPhoto } from '../domain/types';
 import { encodeText, decodeText, md5Hex } from '../infra/utils';
@@ -136,8 +136,8 @@ export class UploadUseCase {
   private async uriToUint8Array(uri: string): Promise<Uint8Array> {
     if (Platform.OS !== 'web' && (uri.startsWith('file:') || uri.startsWith('content:'))) {
         try {
-            const base64 = await FileSystem.readAsStringAsync(uri, { encoding: 'base64' as any });
-            return new Uint8Array(Buffer.from(base64, 'base64'));
+            const file = new File(uri);
+            return await file.bytes();
         } catch (e: any) {
             console.error(`Failed to read local file with FileSystem: ${uri}`, e);
             throw new Error(`Failed to read local file: ${e.message}`);

--- a/frontend/src/usecase/upload.usecase.ts
+++ b/frontend/src/usecase/upload.usecase.ts
@@ -1,5 +1,6 @@
 import * as ImageManipulator from 'expo-image-manipulator';
 import * as MediaLibrary from 'expo-media-library';
+import * as FileSystem from 'expo-file-system';
 import { Platform } from 'react-native';
 import { IS3Repository, ILocalGalleryRepository, S3Credentials, UploadedPhoto } from '../domain/types';
 import { encodeText, decodeText, md5Hex } from '../infra/utils';
@@ -133,6 +134,16 @@ export class UploadUseCase {
   }
 
   private async uriToUint8Array(uri: string): Promise<Uint8Array> {
+    if (Platform.OS !== 'web' && (uri.startsWith('file://') || uri.startsWith('content://'))) {
+        try {
+            const base64 = await FileSystem.readAsStringAsync(uri, { encoding: 'base64' as any });
+            const binary = Buffer.from(base64, 'base64');
+            return new Uint8Array(binary);
+        } catch (e) {
+            console.error('Failed to read local file with FileSystem', e);
+            // Fallback to fetch
+        }
+    }
     const response = await fetch(uri);
     const buffer = await response.arrayBuffer();
     return new Uint8Array(buffer);

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6601,6 +6601,11 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
+process@^0.11.10:
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
+
 progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4188,6 +4188,11 @@ event-target-shim@^5.0.0:
   resolved "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz"
   integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
+events@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
+
 evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4291,7 +4291,7 @@ expo-document-picker@~55.0.9:
   resolved "https://registry.yarnpkg.com/expo-document-picker/-/expo-document-picker-55.0.9.tgz#948b083a50c12024f5f8e889103b1962b4a58a0c"
   integrity sha512-XtkhmZ9alOj1n2Ok782lK9qtfk9TbaBoOJotSDK0pvq5oa+3UyHlLLTUmnC5UPMmFKoLGLJC3R2fLBFEiN5jCQ==
 
-expo-file-system@~55.0.11:
+expo-file-system@^55.0.11, expo-file-system@~55.0.11:
   version "55.0.11"
   resolved "https://registry.yarnpkg.com/expo-file-system/-/expo-file-system-55.0.11.tgz#9be75b499363d40f1329830c685f34e55710d987"
   integrity sha512-KMUd6OY375J9WD79ZvjvCDZMveT7YfgiGWdi58/gfuTBsr14TRuoPk8RRQHAtc4UquzWViKcHwna9aPY7/XPpw==


### PR DESCRIPTION
This change fixes the issues where photos wouldn't load or upload on Android. 

The main fixes include:
1. Enabling the `Buffer` polyfill, which is required for the AWS SDK and SSE-C encryption/decryption.
2. Handling `Blob` objects in `S3Repository.getFile`, as the React Native `fetch` implementation on Android often returns data as a Blob instead of a direct stream or array.
3. Replacing the unreliable `fetch(uri)` with `expo-file-system` in `UploadUseCase` to read local files from `content://` or `file://` URIs during upload.
4. Adding user-visible alerts for upload failures on Android to aid in debugging.
5. Optimizing binary conversions using `Buffer` for better performance.
6. Updating the test infrastructure to support these changes.

---
*PR created automatically by Jules for task [6373650429108169666](https://jules.google.com/task/6373650429108169666) started by @snigle*